### PR TITLE
Add separate category for manual controls

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -2,7 +2,7 @@
 Core data models for the YugabyteDB CIS Benchmark Tool
 """
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -15,6 +15,7 @@ class ControlStatus(Enum):
     WARN = "WARN"
     INFO = "INFO"
     SKIP = "SKIP"
+    MANUAL = "MANUAL"
 
 
 class CheckType(Enum):
@@ -68,6 +69,9 @@ class ControlResult:
     severity: str = "MEDIUM"
     audit_command: Optional[str] = None
     impact: Optional[str] = None
+    manual_steps: Optional[List[str]] = None
+    references: Optional[List[str]] = None
+    compliance_frameworks: Optional[List[str]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization"""
@@ -96,7 +100,15 @@ class SectionSummary:
     failed: int
     warnings: int
     skipped: int
-    pass_percentage: float
+    manual: int = 0
+    
+    def __post_init__(self):
+        """Calculate pass percentage based on automated tests only"""
+        automated_total = self.passed + self.failed + self.skipped
+        if automated_total > 0:
+            self.pass_percentage = (self.passed / automated_total) * 100
+        else:
+            self.pass_percentage = 0.0
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary for JSON serialization"""
@@ -108,29 +120,75 @@ class BenchmarkReport:
     """Complete benchmark report"""
     cluster_info: Dict[str, Any]
     scan_time: datetime
-    total_checks: int
-    passed: int
-    failed: int
-    warnings: int
-    skipped: int
     results: List[ControlResult]
-    section_summaries: List[SectionSummary]
     profile_level: str = "Level 1"
+    
+    section_summaries: List[SectionSummary] = field(init=False)
+    total_checks: int = field(init=False)
+    passed: int = field(init=False)
+    failed: int = field(init=False)
+    warnings: int = field(init=False)
+    skipped: int = field(init=False)
+    manual: int = field(init=False)
+    pass_percentage: float = field(init=False)
 
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary for JSON serialization"""
-        return {
-            'cluster_info': self.cluster_info,
-            'scan_time': self.scan_time.isoformat(),
-            'total_checks': self.total_checks,
-            'passed': self.passed,
-            'failed': self.failed,
-            'warnings': self.warnings,
-            'skipped': self.skipped,
-            'profile_level': self.profile_level,
-            'results': [result.to_dict() for result in self.results],
-            'section_summaries': [summary.to_dict() for summary in self.section_summaries]
-        }
+    def __post_init__(self):
+        """Calculate summary statistics"""
+        self.total_checks = len(self.results)
+        self.passed = sum(1 for r in self.results if r.status == ControlStatus.PASS)
+        self.failed = sum(1 for r in self.results if r.status == ControlStatus.FAIL)
+        self.warnings = sum(1 for r in self.results if r.status == ControlStatus.WARN)
+        self.skipped = sum(1 for r in self.results if r.status == ControlStatus.SKIP)
+        self.manual = sum(1 for r in self.results if r.status == ControlStatus.MANUAL)
+        
+        automated_total = self.passed + self.failed + self.skipped
+        if automated_total > 0:
+            self.pass_percentage = (self.passed / automated_total) * 100
+        else:
+            self.pass_percentage = 0.0
+        
+        self._generate_section_summaries()
+
+    def _generate_section_summaries(self):
+        """Generate section summaries from results"""
+        sections = {}
+        
+        for result in self.results:
+            if result.section not in sections:
+                sections[result.section] = {
+                    'total': 0,
+                    'passed': 0,
+                    'failed': 0,
+                    'warnings': 0,
+                    'skipped': 0,
+                    'manual': 0
+                }
+            
+            sections[result.section]['total'] += 1
+            
+            if result.status == ControlStatus.PASS:
+                sections[result.section]['passed'] += 1
+            elif result.status == ControlStatus.FAIL:
+                sections[result.section]['failed'] += 1
+            elif result.status == ControlStatus.WARN:
+                sections[result.section]['warnings'] += 1
+            elif result.status == ControlStatus.SKIP:
+                sections[result.section]['skipped'] += 1
+            elif result.status == ControlStatus.MANUAL:
+                sections[result.section]['manual'] += 1
+        
+        self.section_summaries = []
+        for name, stats in sections.items():
+            section_summary = SectionSummary(
+                section_name=name,
+                total_controls=stats['total'],
+                passed=stats['passed'],
+                failed=stats['failed'],
+                warnings=stats['warnings'],
+                skipped=stats['skipped'],
+                manual=stats['manual']
+            )
+            self.section_summaries.append(section_summary)
 
     def get_pass_rate(self) -> float:
         """Calculate overall pass rate"""
@@ -149,3 +207,116 @@ class BenchmarkReport:
     def get_results_by_status(self, status: ControlStatus) -> List[ControlResult]:
         """Get all results with specific status"""
         return [result for result in self.results if result.status == status]
+
+
+@dataclass
+class BenchmarkConfig:
+    """Configuration for benchmark execution"""
+    profile_level: str = "L1"  # L1, L2
+    host: str = "localhost"
+    port: int = 5433
+    database: str = "yugabyte"
+    username: str = "yugabyte"
+    password: Optional[str] = None
+    ssl_mode: str = "prefer"
+    connect_timeout: int = 30
+    
+    skip_manual: bool = False           # Skip manual controls entirely
+    include_info: bool = True           # Include informational controls
+    fail_on_manual: bool = False        # Treat manual controls as failures
+    sections: Optional[List[str]] = None  # Specific sections to run
+    controls: Optional[List[str]] = None  # Specific controls to run
+    
+    output_formats: List[str] = field(default_factory=lambda: ["html", "json"])
+    output_dir: str = "./reports"
+    include_passed: bool = True         # Include passed controls in detailed reports
+    verbose: bool = False
+    
+    manual_verification_mode: str = "mark"  # "mark", "skip", "fail"
+    prompt_for_manual: bool = False
+
+
+@dataclass
+class ManualControl:
+    """Definition of a manual control"""
+    control_id: str
+    title: str
+    description: str
+    verification_steps: List[str]
+    expected_result: str
+    remediation: str
+    impact: str
+    profile_level: str
+    section: str
+    references: Optional[List[str]] = None
+    compliance_frameworks: Optional[List[str]] = None
+    severity: str = "MEDIUM"
+
+
+@dataclass
+class ComplianceFramework:
+    """Compliance framework mapping"""
+    name: str                           # CIS, SOC2, PCI-DSS, etc.
+    version: str
+    control_mappings: Dict[str, str]    # control_id -> framework_control_id
+    requirements: List[str]             # List of framework requirements
+
+def get_status_priority(status: ControlStatus) -> int:
+    """Get priority for status sorting (lower number = higher priority)"""
+    priority_map = {
+        ControlStatus.FAIL: 1,
+        ControlStatus.MANUAL: 2,
+        ControlStatus.SKIP: 3,
+        ControlStatus.INFO: 4,
+        ControlStatus.PASS: 5
+    }
+    return priority_map.get(status, 999)
+
+
+def get_status_color(status: ControlStatus) -> str:
+    """Get color code for status"""
+    color_map = {
+        ControlStatus.PASS: "#22C55E",      # Green
+        ControlStatus.FAIL: "#EF4444",      # Red
+        ControlStatus.SKIP: "#6B7280",      # Gray
+        ControlStatus.INFO: "#06B6D4",      # Cyan
+        ControlStatus.MANUAL: "#8B5CF6"     # Purple
+    }
+    return color_map.get(status, "#6B7280")
+
+
+def get_status_icon(status: ControlStatus) -> str:
+    """Get icon for status"""
+    icon_map = {
+        ControlStatus.PASS: "✅",
+        ControlStatus.FAIL: "❌",
+        ControlStatus.SKIP: "⏭️",
+        ControlStatus.INFO: "ℹ️",
+        ControlStatus.MANUAL: "👤"
+    }
+    return icon_map.get(status, "❓")
+
+
+def create_manual_control_result(
+    control_id: str,
+    title: str,
+    section: str,
+    profile_level: str,
+    verification_steps: List[str],
+    remediation: str = "",
+    impact: str = "",
+    references: List[str] = None
+) -> ControlResult:
+    """Create a ControlResult for a manual control"""
+    return ControlResult(
+        control_id=control_id,
+        title=title,
+        status=ControlStatus.MANUAL,
+        message="Manual verification required - please review the verification steps below",
+        profile_level=profile_level,
+        section=section,
+        manual_steps=verification_steps,
+        remediation=remediation,
+        impact=impact,
+        references=references or []
+    )

--- a/reports/csv_reporter.py
+++ b/reports/csv_reporter.py
@@ -3,101 +3,407 @@ CSV Report Generator for YugabyteDB CIS Benchmark Tool
 """
 
 import csv
-
-from core.models import BenchmarkReport
+from datetime import datetime
+from typing import List, Dict, Any
+from core.models import BenchmarkReport, ControlStatus
 
 
 class CSVReporter:
-    """Generate CSV format reports"""
+    """Generate CSV format reports with Manual controls support"""
 
     @staticmethod
     def generate_report(report: BenchmarkReport, output_file: str):
         """Generate CSV report and save to file"""
-        CSVReporter._write_main_results_csv(report, output_file)
-
-        # Generate additional CSV files
-        base_name = output_file.rsplit('.', 1)[0]
-        CSVReporter._write_summary_csv(report, f"{base_name}_summary.csv")
-        CSVReporter._write_section_summary_csv(report, f"{base_name}_sections.csv")
+        with open(output_file, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            CSVReporter._write_csv_content(writer, report)
 
     @staticmethod
-    def _write_main_results_csv(report: BenchmarkReport, output_file: str):
-        """Write main results to CSV"""
+    def generate_summary_report(report: BenchmarkReport, output_file: str):
+        """Generate summary CSV report"""
+        with open(output_file, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            CSVReporter._write_summary_csv(writer, report)
+
     @staticmethod
-    def _write_main_results_csv(report: BenchmarkReport, output_file: str):
-        """Write main results to CSV"""
-        fieldnames = [
-            'control_id', 'title', 'section', 'status', 'message',
-            'profile_level', 'expected', 'actual', 'severity',
-            'audit_command', 'remediation', 'impact'
+    def generate_manual_controls_report(report: BenchmarkReport, output_file: str):
+        """Generate CSV report specifically for manual controls"""
+        manual_controls = [r for r in report.results if r.status == ControlStatus.MANUAL]
+        
+        with open(output_file, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            CSVReporter._write_manual_controls_csv(writer, manual_controls, report)
+
+    @staticmethod
+    def _write_csv_content(writer: csv.writer, report: BenchmarkReport):
+        """Write detailed CSV content"""
+        # Write metadata header
+        CSVReporter._write_metadata_section(writer, report)
+        
+        # Write summary section
+        CSVReporter._write_summary_section(writer, report)
+        
+        # Write detailed results
+        CSVReporter._write_detailed_results(writer, report)
+
+    @staticmethod
+    def _write_metadata_section(writer: csv.writer, report: BenchmarkReport):
+        """Write metadata section"""
+        writer.writerow(['=== YUGABYTEDB CIS BENCHMARK REPORT ==='])
+        writer.writerow([])
+        writer.writerow(['Report Metadata'])
+        writer.writerow(['Profile Level', report.profile_level])
+        writer.writerow(['Cluster Host', report.cluster_info.get('host', 'Unknown')])
+        writer.writerow(['Cluster Port', report.cluster_info.get('port', 'Unknown')])
+        writer.writerow(['Database', report.cluster_info.get('database', 'Unknown')])
+        writer.writerow(['Version', report.cluster_info.get('version', 'Unknown')])
+        writer.writerow(['Scan Time', report.scan_time.strftime('%Y-%m-%d %H:%M:%S')])
+        writer.writerow([])
+
+    @staticmethod
+    def _write_summary_section(writer: csv.writer, report: BenchmarkReport):
+        """Write summary section with Manual controls"""
+        writer.writerow(['Summary Statistics'])
+        writer.writerow(['Metric', 'Count', 'Percentage'])
+        
+        total = report.total_checks
+        writer.writerow(['Total Checks', total, '100.0%'])
+        writer.writerow(['Passed', report.passed, f'{(report.passed/total*100):.1f}%' if total > 0 else '0.0%'])
+        writer.writerow(['Failed', report.failed, f'{(report.failed/total*100):.1f}%' if total > 0 else '0.0%'])
+        writer.writerow(['Skipped', report.skipped, f'{(report.skipped/total*100):.1f}%' if total > 0 else '0.0%'])
+        writer.writerow(['Manual', report.manual, f'{(report.manual/total*100):.1f}%' if total > 0 else '0.0%'])
+        
+        # Automated tests statistics
+        automated_total = report.passed + report.failed + report.skipped
+        automated_pass_rate = (report.passed / automated_total * 100) if automated_total > 0 else 0
+        writer.writerow(['Automated Tests Total', automated_total, f'{(automated_total/total*100):.1f}%' if total > 0 else '0.0%'])
+        writer.writerow(['Automated Pass Rate', report.passed, f'{automated_pass_rate:.1f}%'])
+        
+        writer.writerow([])
+
+    @staticmethod
+    def _write_detailed_results(writer: csv.writer, report: BenchmarkReport):
+        """Write detailed results section"""
+        writer.writerow(['Detailed Results'])
+        
+        # CSV Column Headers
+        headers = [
+            'Control ID',
+            'Title', 
+            'Status',
+            'Section',
+            'Profile Level',
+            'Message',
+            'Severity',
+            'Expected',
+            'Actual',
+            'Audit Command',
+            'Remediation',
+            'Impact',
+            'Manual Steps',
+            'References'
         ]
-
-        with open(output_file, 'w', newline='', encoding='utf-8') as csvfile:
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-            writer.writeheader()
-
-            for result in report.results:
-                writer.writerow({
-                    'control_id': result.control_id,
-                    'title': result.title,
-                    'section': result.section,
-                    'status': result.status.value,
-                    'message': result.message,
-                    'profile_level': result.profile_level,
-                    'expected': result.expected or '',
-                    'actual': result.actual or '',
-                    'severity': result.severity,
-                    'audit_command': result.audit_command or '',
-                    'remediation': result.remediation or '',
-                    'impact': result.impact or ''
-                })
-
-    @staticmethod
-    def _write_summary_csv(report: BenchmarkReport, output_file: str):
-        """Write summary information to CSV"""
-        with open(output_file, 'w', newline='', encoding='utf-8') as csvfile:
-            writer = csv.writer(csvfile)
-
-            # Write header
-            writer.writerow(['Metric', 'Value'])
-
-            # Write cluster information
-            writer.writerow(['Cluster Host', report.cluster_info.get('host', 'Unknown')])
-            writer.writerow(['Cluster Port', report.cluster_info.get('port', 'Unknown')])
-            writer.writerow(['Database', report.cluster_info.get('database', 'Unknown')])
-            writer.writerow(['Version', report.cluster_info.get('version', 'Unknown')])
-            writer.writerow(['Scan Time', report.scan_time.strftime('%Y-%m-%d %H:%M:%S')])
-            writer.writerow(['Profile Level', report.profile_level])
-
-            # Write summary statistics
-            writer.writerow([])  # Empty row for separation
-            writer.writerow(['Summary Statistics', ''])
-            writer.writerow(['Total Checks', report.total_checks])
-            writer.writerow(['Passed', report.passed])
-            writer.writerow(['Failed', report.failed])
-            writer.writerow(['Warnings', report.warnings])
-            writer.writerow(['Skipped', report.skipped])
-            writer.writerow(['Pass Rate (%)', f"{report.get_pass_rate():.1f}"])
+        writer.writerow(headers)
+        
+        # Sort results by status priority and control ID
+        sorted_results = sorted(
+            report.results, 
+            key=lambda x: (CSVReporter._get_status_priority(x.status), x.control_id)
+        )
+        
+        for result in sorted_results:
+            # Handle manual steps formatting
+            manual_steps = ''
+            if result.status == ControlStatus.MANUAL and result.manual_steps:
+                manual_steps = ' | '.join(result.manual_steps)
+            
+            # Handle references formatting
+            references = ''
+            if hasattr(result, 'references') and result.references:
+                references = ' | '.join(result.references)
+            
+            row = [
+                result.control_id,
+                result.title,
+                result.status.value,
+                result.section,
+                result.profile_level,
+                result.message,
+                getattr(result, 'severity', 'MEDIUM'),
+                result.expected or '',
+                result.actual or '',
+                result.audit_command or '',
+                result.remediation or '',
+                result.impact or '',
+                manual_steps,
+                references
+            ]
+            writer.writerow(row)
 
     @staticmethod
-    def _write_section_summary_csv(report: BenchmarkReport, output_file: str):
-        """Write section summaries to CSV"""
-        fieldnames = [
-            'section_name', 'total_controls', 'passed', 'failed',
-            'warnings', 'skipped', 'pass_percentage'
+    def _write_summary_csv(writer: csv.writer, report: BenchmarkReport):
+        """Write summary-only CSV"""
+        writer.writerow(['YugabyteDB CIS Benchmark Summary Report'])
+        writer.writerow(['Generated:', datetime.now().strftime('%Y-%m-%d %H:%M:%S')])
+        writer.writerow([])
+        
+        # Overall Summary
+        writer.writerow(['Overall Summary'])
+        writer.writerow(['Total Checks', report.total_checks])
+        writer.writerow(['Passed', report.passed])
+        writer.writerow(['Failed', report.failed])
+        writer.writerow(['Skipped', report.skipped])
+        writer.writerow(['Manual', report.manual])
+        writer.writerow(['Automated Pass Rate', f'{report.pass_percentage:.1f}%'])
+        writer.writerow([])
+        
+        # Section Summaries
+        writer.writerow(['Section Summaries'])
+        writer.writerow(['Section', 'Total', 'Passed', 'Failed', 'Skipped', 'Manual', 'Auto Pass Rate'])
+        
+        for section in report.section_summaries:
+            automated_total = section.passed + section.failed + section.skipped
+            auto_pass_rate = (section.passed / automated_total * 100) if automated_total > 0 else 0
+            
+            writer.writerow([
+                section.section_name,
+                section.total_controls,
+                section.passed,
+                section.failed,
+                section.skipped,
+                section.manual,
+                f'{auto_pass_rate:.1f}%'
+            ])
+
+    @staticmethod
+    def _write_manual_controls_csv(writer: csv.writer, manual_controls: List, report: BenchmarkReport):
+        """Write CSV specifically for manual controls"""
+        writer.writerow(['YugabyteDB CIS Benchmark - Manual Verification Controls'])
+        writer.writerow(['Generated:', datetime.now().strftime('%Y-%m-%d %H:%M:%S')])
+        writer.writerow(['Profile Level:', report.profile_level])
+        writer.writerow([])
+        
+        writer.writerow([f'Total Manual Controls: {len(manual_controls)}'])
+        writer.writerow(['Estimated Total Verification Time:', f'{len(manual_controls) * 10} minutes'])
+        writer.writerow([])
+        
+        # Headers for manual controls
+        headers = [
+            'Control ID',
+            'Title',
+            'Section',
+            'Profile Level',
+            'Severity',
+            'Verification Steps',
+            'Expected Result',
+            'Remediation',
+            'Impact',
+            'References',
+            'Estimated Time',
+            'Verification Status',
+            'Verifier',
+            'Verification Date',
+            'Notes'
         ]
+        writer.writerow(headers)
+        
+        for control in manual_controls:
+            # Format verification steps
+            steps = ' | '.join(control.manual_steps) if control.manual_steps else 'See CIS documentation'
+            
+            # Format references
+            references = ' | '.join(control.references) if hasattr(control, 'references') and control.references else ''
+            
+            row = [
+                control.control_id,
+                control.title,
+                control.section,
+                control.profile_level,
+                getattr(control, 'severity', 'MEDIUM'),
+                steps,
+                control.expected or 'Manual verification required',
+                control.remediation or '',
+                control.impact or '',
+                references,
+                '5-15 minutes',
+                '',  # To be filled by verifier
+                '',  # To be filled by verifier
+                '',  # To be filled by verifier
+                ''   # To be filled by verifier
+            ]
+            writer.writerow(row)
+        
+        writer.writerow([])
+        writer.writerow(['Verification Instructions:'])
+        writer.writerow(['1. Review each control and its verification steps'])
+        writer.writerow(['2. Perform the manual verification as described'])
+        writer.writerow(['3. Update Verification Status (PASS/FAIL/N/A)'])
+        writer.writerow(['4. Record your name in Verifier column'])
+        writer.writerow(['5. Record verification date'])
+        writer.writerow(['6. Add any relevant notes'])
 
-        with open(output_file, 'w', newline='', encoding='utf-8') as csvfile:
-            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-            writer.writeheader()
+    @staticmethod
+    def _get_status_priority(status: ControlStatus) -> int:
+        """Get priority for status sorting"""
+        priority_map = {
+            ControlStatus.FAIL: 1,
+            ControlStatus.MANUAL: 2,
+            ControlStatus.SKIP: 3,
+            ControlStatus.INFO: 4,
+            ControlStatus.PASS: 5
+        }
+        return priority_map.get(status, 999)
 
-            for section in report.section_summaries:
-                writer.writerow({
-                    'section_name': section.section_name,
-                    'total_controls': section.total_controls,
-                    'passed': section.passed,
-                    'failed': section.failed,
-                    'warnings': section.warnings,
-                    'skipped': section.skipped,
-                    'pass_percentage': f"{section.pass_percentage:.1f}"
-                })
+    @staticmethod
+    def generate_compliance_csv(report: BenchmarkReport, output_file: str):
+        """Generate compliance-focused CSV report"""
+        with open(output_file, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            
+            writer.writerow(['YugabyteDB CIS Benchmark - Compliance Report'])
+            writer.writerow(['Generated:', datetime.now().strftime('%Y-%m-%d %H:%M:%S')])
+            writer.writerow([])
+            
+            # Compliance status overview
+            writer.writerow(['Compliance Status Overview'])
+            writer.writerow(['Framework', 'Version', 'Total Controls', 'Compliant', 'Non-Compliant', 'Manual Review', 'Compliance %'])
+            
+            automated_total = report.passed + report.failed + report.skipped
+            compliance_rate = (report.passed / automated_total * 100) if automated_total > 0 else 0
+            
+            writer.writerow([
+                'CIS Benchmark',
+                '1.0.0',
+                report.total_checks,
+                report.passed,
+                report.failed + report.skipped,  # Non-compliant includes skipped
+                report.manual,
+                f'{compliance_rate:.1f}%'
+            ])
+            writer.writerow([])
+            
+            # Gap analysis
+            writer.writerow(['Compliance Gaps (Failed Controls)'])
+            writer.writerow(['Priority', 'Control ID', 'Title', 'Section', 'Severity', 'Remediation Required'])
+            
+            failed_controls = [r for r in report.results if r.status == ControlStatus.FAIL]
+            # Sort by severity
+            severity_order = {'CRITICAL': 0, 'HIGH': 1, 'MEDIUM': 2, 'LOW': 3}
+            failed_controls.sort(key=lambda x: severity_order.get(getattr(x, 'severity', 'MEDIUM'), 99))
+            
+            for i, control in enumerate(failed_controls, 1):
+                priority = 'IMMEDIATE' if getattr(control, 'severity', 'MEDIUM') in ['CRITICAL', 'HIGH'] else 'HIGH'
+                writer.writerow([
+                    priority,
+                    control.control_id,
+                    control.title,
+                    control.section,
+                    getattr(control, 'severity', 'MEDIUM'),
+                    'Yes' if control.remediation else 'See documentation'
+                ])
+            
+            writer.writerow([])
+            
+            # Manual verification requirements
+            writer.writerow(['Manual Verification Requirements'])
+            writer.writerow(['Control ID', 'Title', 'Section', 'Severity', 'Review Priority', 'Est. Time'])
+            
+            manual_controls = [r for r in report.results if r.status == ControlStatus.MANUAL]
+            manual_controls.sort(key=lambda x: severity_order.get(getattr(x, 'severity', 'MEDIUM'), 99))
+            
+            for control in manual_controls:
+                severity = getattr(control, 'severity', 'MEDIUM')
+                priority = 'HIGH' if severity in ['CRITICAL', 'HIGH'] else 'MEDIUM'
+                
+                writer.writerow([
+                    control.control_id,
+                    control.title,
+                    control.section,
+                    severity,
+                    priority,
+                    '10-15 min'
+                ])
+
+    @staticmethod
+    def generate_action_plan_csv(report: BenchmarkReport, output_file: str):
+        """Generate action plan CSV for remediation"""
+        with open(output_file, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            
+            writer.writerow(['YugabyteDB CIS Benchmark - Action Plan'])
+            writer.writerow(['Generated:', datetime.now().strftime('%Y-%m-%d %H:%M:%S')])
+            writer.writerow([])
+            
+            headers = [
+                'Priority',
+                'Control ID',
+                'Title',
+                'Section',
+                'Current Status',
+                'Required Action',
+                'Remediation Steps',
+                'Impact Level',
+                'Estimated Effort',
+                'Target Date',
+                'Assigned To',
+                'Status',
+                'Notes'
+            ]
+            writer.writerow(headers)
+            
+            # Process failed controls first (highest priority)
+            failed_controls = [r for r in report.results if r.status == ControlStatus.FAIL]
+            manual_controls = [r for r in report.results if r.status == ControlStatus.MANUAL]
+            
+            all_action_items = []
+            
+            # Add failed controls
+            for control in failed_controls:
+                severity = getattr(control, 'severity', 'MEDIUM')
+                priority = 'P1 - CRITICAL' if severity == 'CRITICAL' else 'P2 - HIGH' if severity == 'HIGH' else 'P3 - MEDIUM'
+                effort = 'High' if severity in ['CRITICAL', 'HIGH'] else 'Medium'
+                
+                all_action_items.append([
+                    priority,
+                    control.control_id,
+                    control.title,
+                    control.section,
+                    'FAILED',
+                    'Implement Security Control',
+                    control.remediation or 'See CIS benchmark documentation',
+                    control.impact or 'Security risk',
+                    effort,
+                    '',  # To be filled
+                    '',  # To be filled
+                    'Open',
+                    ''   # To be filled
+                ])
+            
+            # Add high-priority manual controls
+            for control in manual_controls:
+                severity = getattr(control, 'severity', 'MEDIUM')
+                if severity in ['CRITICAL', 'HIGH']:
+                    priority = 'P2 - HIGH' if severity == 'CRITICAL' else 'P3 - MEDIUM'
+                    
+                    all_action_items.append([
+                        priority,
+                        control.control_id,
+                        control.title,
+                        control.section,
+                        'MANUAL REVIEW REQUIRED',
+                        'Complete Manual Verification',
+                        ' | '.join(control.manual_steps) if control.manual_steps else 'Perform manual review',
+                        control.impact or 'Compliance verification',
+                        'Low',
+                        '',  # To be filled
+                        '',  # To be filled
+                        'Open',
+                        ''   # To be filled
+                    ])
+            
+            # Sort by priority
+            priority_order = {'P1 - CRITICAL': 0, 'P2 - HIGH': 1, 'P3 - MEDIUM': 2, 'P4 - LOW': 3}
+            all_action_items.sort(key=lambda x: priority_order.get(x[0], 99))
+            
+            for item in all_action_items:
+                writer.writerow(item)

--- a/reports/json_reporter.py
+++ b/reports/json_reporter.py
@@ -4,96 +4,340 @@ JSON Report Generator for YugabyteDB CIS Benchmark Tool
 
 import json
 from datetime import datetime
-
-from core.models import BenchmarkReport
+from typing import Dict, Any, List
+from core.models import BenchmarkReport, ControlStatus
 
 
 class JSONReporter:
-    """Generate JSON format reports"""
+    """Generate JSON format reports with Manual controls support"""
 
     @staticmethod
     def generate_report(report: BenchmarkReport, output_file: str):
         """Generate JSON report and save to file"""
-        report_data = JSONReporter._prepare_report_data(report)
-
+        json_data = JSONReporter._generate_json_data(report)
+        
         with open(output_file, 'w', encoding='utf-8') as f:
-            json.dump(report_data, f, indent=2, ensure_ascii=False, default=str)
+            json.dump(json_data, f, indent=2, ensure_ascii=False, default=JSONReporter._json_serializer)
 
     @staticmethod
-    def _prepare_report_data(report: BenchmarkReport) -> dict:
-        """Prepare report data for JSON serialization"""
+    def _json_serializer(obj):
+        """Custom JSON serializer for datetime and enum objects"""
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        elif isinstance(obj, ControlStatus):
+            return obj.value
+        raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+    @staticmethod
+    def _generate_json_data(report: BenchmarkReport) -> Dict[str, Any]:
+        """Generate complete JSON data structure"""
         return {
-            "metadata": {
-                "report_type": "YugabyteDB CIS Benchmark",
-                "profile_level": report.profile_level,
-                "generated_at": report.scan_time.isoformat(),
-                "version": "1.0",
-                "tool": "YugabyteDB CIS Benchmark Tool"
-            },
+            "metadata": JSONReporter._generate_metadata(report),
+            "summary": JSONReporter._generate_summary(report),
+            "section_summaries": JSONReporter._generate_section_summaries(report),
+            "controls": JSONReporter._generate_controls_data(report),
+            "compliance": JSONReporter._generate_compliance_data(report),
+            "recommendations": JSONReporter._generate_recommendations(report)
+        }
+
+    @staticmethod
+    def _generate_metadata(report: BenchmarkReport) -> Dict[str, Any]:
+        """Generate metadata section"""
+        return {
+            "report_type": "YugabyteDB CIS Benchmark",
+            "version": "1.0.0",
+            "profile_level": report.profile_level,
+            "scan_time": report.scan_time,
             "cluster_info": report.cluster_info,
-            "summary": {
-                "total_checks": report.total_checks,
-                "passed": report.passed,
-                "failed": report.failed,
-                "warnings": report.warnings,
-                "skipped": report.skipped,
-                "pass_rate": report.get_pass_rate()
-            },
-            "section_summaries": [summary.to_dict() for summary in report.section_summaries],
-            "results": [result.to_dict() for result in report.results],
-            "statistics": JSONReporter._generate_statistics(report)
+            "total_execution_time": JSONReporter._calculate_execution_time(report),
+            "report_format_version": "2.0",
+            "supports_manual_controls": True
         }
 
     @staticmethod
-    def _generate_statistics(report: BenchmarkReport) -> dict:
-        """Generate additional statistics"""
-        results_by_status = {}
-        results_by_section = {}
+    def _calculate_execution_time(report: BenchmarkReport) -> str:
+        """Calculate estimated execution time"""
+        # This would be calculated during actual execution
+        # For now, return a placeholder
+        return "< 1 minute"
 
-        # Count by status
-        for result in report.results:
-            status = result.status.value
-            results_by_status[status] = results_by_status.get(status, 0) + 1
-
-            # Count by section
-            section = result.section
-            if section not in results_by_section:
-                results_by_section[section] = {
-                    "total": 0, "passed": 0, "failed": 0, "warnings": 0, "skipped": 0, "info": 0
-                }
-
-            results_by_section[section]["total"] += 1
-            if result.status.value == "PASS":
-                results_by_section[section]["passed"] += 1
-            elif result.status.value == "FAIL":
-                results_by_section[section]["failed"] += 1
-            elif result.status.value == "WARN":
-                results_by_section[section]["warnings"] += 1
-            elif result.status.value == "SKIP":
-                results_by_section[section]["skipped"] += 1
-            elif result.status.value == "INFO":
-                results_by_section[section]["info"] += 1
-
+    @staticmethod
+    def _generate_summary(report: BenchmarkReport) -> Dict[str, Any]:
+        """Generate summary statistics with Manual controls"""
+        automated_total = report.passed + report.failed + report.skipped
+        
         return {
-            "results_by_status": results_by_status,
-            "results_by_section": results_by_section,
-            "compliance_score": report.get_pass_rate(),
-            "risk_level": JSONReporter._calculate_risk_level(report)
+            "total_checks": report.total_checks,
+            "passed": report.passed,
+            "failed": report.failed,
+            "skipped": report.skipped,
+            "manual": report.manual,
+            "info": sum(1 for r in report.results if r.status == ControlStatus.INFO),
+            "pass_percentage": round(report.pass_percentage, 2),
+            "automated_checks": automated_total,
+            "automated_pass_percentage": round((report.passed / automated_total * 100) if automated_total > 0 else 0, 2),
+            "critical_failures": JSONReporter._count_critical_failures(report),
+            "high_priority_manual": JSONReporter._count_high_priority_manual(report),
+            "status_distribution": {
+                "PASS": report.passed,
+                "FAIL": report.failed,
+                "SKIP": report.skipped,
+                "MANUAL": report.manual,
+                "INFO": sum(1 for r in report.results if r.status == ControlStatus.INFO)
+            }
         }
 
     @staticmethod
-    def _calculate_risk_level(report: BenchmarkReport) -> str:
-        """Calculate overall risk level based on results"""
-        if report.total_checks == 0:
-            return "Unknown"
+    def _count_critical_failures(report: BenchmarkReport) -> int:
+        """Count critical/high severity failures"""
+        return sum(1 for r in report.results 
+                  if r.status == ControlStatus.FAIL and 
+                  getattr(r, 'severity', 'MEDIUM') in ['CRITICAL', 'HIGH'])
 
-        fail_rate = (report.failed / report.total_checks) * 100
+    @staticmethod
+    def _count_high_priority_manual(report: BenchmarkReport) -> int:
+        """Count high priority manual controls"""
+        return sum(1 for r in report.results 
+                  if r.status == ControlStatus.MANUAL and 
+                  getattr(r, 'severity', 'MEDIUM') in ['CRITICAL', 'HIGH'])
 
-        if fail_rate == 0:
-            return "Low"
-        elif fail_rate < 10:
-            return "Medium"
-        elif fail_rate < 25:
-            return "High"
+    @staticmethod
+    def _generate_section_summaries(report: BenchmarkReport) -> List[Dict[str, Any]]:
+        """Generate section summaries with Manual controls"""
+        summaries = []
+        
+        for section in report.section_summaries:
+            automated_total = section.passed + section.failed + section.skipped
+            
+            summary = {
+                "section_name": section.section_name,
+                "total_controls": section.total_controls,
+                "passed": section.passed,
+                "failed": section.failed,
+                "skipped": section.skipped,
+                "manual": section.manual,
+                "pass_percentage": round(section.pass_percentage, 2),
+                "automated_total": automated_total,
+                "automated_pass_percentage": round((section.passed / automated_total * 100) if automated_total > 0 else 0, 2),
+                "risk_level": JSONReporter._calculate_section_risk_level(section),
+                "priority_controls": JSONReporter._get_section_priority_controls(report, section.section_name)
+            }
+            summaries.append(summary)
+        
+        return summaries
+
+    @staticmethod
+    def _calculate_section_risk_level(section) -> str:
+        """Calculate risk level for a section"""
+        fail_rate = (section.failed / (section.passed + section.failed)) * 100 if (section.passed + section.failed) > 0 else 0
+        
+        if fail_rate >= 50:
+            return "HIGH"
+        elif fail_rate >= 25:
+            return "MEDIUM"
         else:
-            return "Critical"
+            return "LOW"
+
+    @staticmethod
+    def _get_section_priority_controls(report: BenchmarkReport, section_name: str) -> List[str]:
+        """Get priority controls for a section (failed + high priority manual)"""
+        priority_controls = []
+        
+        for result in report.results:
+            if result.section == section_name:
+                if result.status == ControlStatus.FAIL:
+                    priority_controls.append(result.control_id)
+                elif (result.status == ControlStatus.MANUAL and 
+                      getattr(result, 'severity', 'MEDIUM') in ['CRITICAL', 'HIGH']):
+                    priority_controls.append(result.control_id)
+        
+        return priority_controls[:5]  # Return top 5 priority controls
+
+    @staticmethod
+    def _generate_controls_data(report: BenchmarkReport) -> List[Dict[str, Any]]:
+        """Generate detailed controls data"""
+        controls = []
+        
+        for result in report.results:
+            control_data = {
+                "control_id": result.control_id,
+                "title": result.title,
+                "status": result.status,
+                "message": result.message,
+                "profile_level": result.profile_level,
+                "section": result.section,
+                "severity": getattr(result, 'severity', 'MEDIUM'),
+                "timestamp": datetime.now()  # Would be actual execution timestamp
+            }
+            
+            # Add optional fields if present
+            if result.expected:
+                control_data["expected"] = result.expected
+            if result.actual:
+                control_data["actual"] = result.actual
+            if result.audit_command:
+                control_data["audit_command"] = result.audit_command
+            if result.remediation:
+                control_data["remediation"] = result.remediation
+            if result.impact:
+                control_data["impact"] = result.impact
+            if result.references:
+                control_data["references"] = result.references
+            
+            # Add Manual control specific fields
+            if result.status == ControlStatus.MANUAL:
+                control_data["manual_verification"] = {
+                    "required": True,
+                    "steps": result.manual_steps or [],
+                    "verification_method": "manual_review",
+                    "estimated_time": "5-15 minutes",
+                    "requires_admin_access": True
+                }
+            
+            # Add compliance framework mappings if available
+            if hasattr(result, 'compliance_frameworks') and result.compliance_frameworks:
+                control_data["compliance_frameworks"] = result.compliance_frameworks
+            
+            controls.append(control_data)
+        
+        return controls
+
+    @staticmethod
+    def _generate_compliance_data(report: BenchmarkReport) -> Dict[str, Any]:
+        """Generate compliance framework data"""
+        compliance_data = {
+            "frameworks": {
+                "CIS": {
+                    "version": "1.0.0",
+                    "applicable_controls": report.total_checks,
+                    "compliant_controls": report.passed,
+                    "non_compliant_controls": report.failed,
+                    "manual_verification_required": report.manual,
+                    "compliance_percentage": round(report.pass_percentage, 2)
+                }
+            },
+            "compliance_gaps": JSONReporter._identify_compliance_gaps(report),
+            "manual_verification_requirements": JSONReporter._get_manual_verification_summary(report)
+        }
+        
+        return compliance_data
+
+    @staticmethod
+    def _identify_compliance_gaps(report: BenchmarkReport) -> List[Dict[str, Any]]:
+        """Identify major compliance gaps"""
+        gaps = []
+        
+        for result in report.results:
+            if result.status == ControlStatus.FAIL:
+                gap = {
+                    "control_id": result.control_id,
+                    "title": result.title,
+                    "section": result.section,
+                    "severity": getattr(result, 'severity', 'MEDIUM'),
+                    "impact": result.impact or "Not specified",
+                    "remediation_priority": JSONReporter._get_remediation_priority(result)
+                }
+                gaps.append(gap)
+        
+        # Sort by severity and return top gaps
+        severity_order = {'CRITICAL': 0, 'HIGH': 1, 'MEDIUM': 2, 'LOW': 3}
+        gaps.sort(key=lambda x: severity_order.get(x['severity'], 99))
+        
+        return gaps[:10]  # Return top 10 gaps
+
+    @staticmethod
+    def _get_remediation_priority(result) -> str:
+        """Get remediation priority based on severity and impact"""
+        severity = getattr(result, 'severity', 'MEDIUM')
+        
+        if severity in ['CRITICAL', 'HIGH']:
+            return 'IMMEDIATE'
+        elif severity == 'MEDIUM':
+            return 'HIGH'
+        else:
+            return 'MEDIUM'
+
+    @staticmethod
+    def _get_manual_verification_summary(report: BenchmarkReport) -> Dict[str, Any]:
+        """Get summary of manual verification requirements"""
+        manual_controls = [r for r in report.results if r.status == ControlStatus.MANUAL]
+        
+        sections_with_manual = {}
+        for control in manual_controls:
+            if control.section not in sections_with_manual:
+                sections_with_manual[control.section] = []
+            sections_with_manual[control.section].append({
+                "control_id": control.control_id,
+                "title": control.title,
+                
+                "severity": getattr(control, 'severity', 'MEDIUM'),
+                "estimated_time": "5-15 minutes"
+            })
+        
+        return {
+            "total_manual_controls": len(manual_controls),
+            "high_priority_manual": JSONReporter._count_high_priority_manual(report),
+            "estimated_total_time": f"{len(manual_controls) * 10} minutes",
+            "sections_requiring_manual_review": sections_with_manual,
+            "verification_guidelines": [
+                "Review each manual control carefully",
+                "Document verification steps taken",
+                "Maintain evidence for compliance audits",
+                "Schedule regular manual reviews"
+            ]
+        }
+
+    @staticmethod
+    def _generate_recommendations(report: BenchmarkReport) -> Dict[str, Any]:
+        """Generate actionable recommendations"""
+        recommendations = {
+            "immediate_actions": [],
+            "short_term_improvements": [],
+            "long_term_strategy": [],
+            "manual_verification_plan": []
+        }
+        
+        # Immediate actions (critical failures)
+        for result in report.results:
+            if (result.status == ControlStatus.FAIL and 
+                getattr(result, 'severity', 'MEDIUM') == 'CRITICAL'):
+                recommendations["immediate_actions"].append({
+                    "control_id": result.control_id,
+                    "action": f"Address critical failure: {result.title}",
+                    "remediation": result.remediation or "See control documentation"
+                })
+        
+        # Short-term improvements (high priority failures and manual controls)
+        for result in report.results:
+            if (result.status == ControlStatus.FAIL and 
+                getattr(result, 'severity', 'MEDIUM') == 'HIGH'):
+                recommendations["short_term_improvements"].append({
+                    "control_id": result.control_id,
+                    "action": f"Implement: {result.title}",
+                    "remediation": result.remediation or "See control documentation"
+                })
+            elif (result.status == ControlStatus.MANUAL and 
+                  getattr(result, 'severity', 'MEDIUM') in ['CRITICAL', 'HIGH']):
+                recommendations["manual_verification_plan"].append({
+                    "control_id": result.control_id,
+                    "action": f"Manual review required: {result.title}",
+                    "steps": result.manual_steps or [],
+                    "remediation": result.remediation or "See control documentation"
+                })
+        
+        # Long-term strategy
+        if report.pass_percentage < 80:
+            recommendations["long_term_strategy"].append({
+                "area": "Overall Security Posture",
+                "recommendation": "Develop comprehensive security improvement plan",
+                "details": "Current pass rate is below recommended 80% threshold"
+            })
+        
+        if report.manual > 0:
+            recommendations["long_term_strategy"].append({
+                "area": "Manual Process Automation",
+                "recommendation": "Consider automating manual verification processes where possible",
+                "details": f"{report.manual} controls currently require manual verification"
+            })
+        
+        return recommendations


### PR DESCRIPTION
- Added separate category for manual controls.
- Each section has manual control count.
- For manual control there is steps available.

Summary section with manual controls:
<img width="1185" height="220" alt="Screenshot 2025-10-01 at 2 10 10 PM" src="https://github.com/user-attachments/assets/32349baf-4672-4351-b762-449ccaf62fc9" />

Example of manual control:
<img width="1098" height="793" alt="Screenshot 2025-10-01 at 2 10 44 PM" src="https://github.com/user-attachments/assets/75fe3bb7-150b-45c5-b7bd-c91881d4fd7f" />
